### PR TITLE
feat: factor out and organize build flags from avr32/windows presets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,44 @@ project(micromouse_software_project LANGUAGES C CXX)
 option(TARGET_AVR32 "Build for AVR32 MCU" OFF)
 option(TARGET_WINDOWS "Build for Windows (unit tests)" OFF)
 
+# Assemble compiler/linker flags from preset fragments
+# ==============================================================================
+if(DEFINED COMMON_C_FLAGS_DEBUG)
+    set(CMAKE_C_FLAGS_DEBUG
+        "${COMMON_C_FLAGS_DEBUG} ${PLATFORM_C_FLAGS_DEBUG}"
+        CACHE STRING "" FORCE
+    )
+endif()
+
+if(DEFINED COMMON_ASM_FLAGS_DEBUG)
+    set(CMAKE_ASM_FLAGS_DEBUG
+        "${COMMON_ASM_FLAGS_DEBUG} ${PLATFORM_ASM_FLAGS_DEBUG}"
+        CACHE STRING "" FORCE
+    )
+endif()
+
+if(DEFINED PLATFORM_C_FLAGS)
+    set(CMAKE_C_FLAGS
+        "${PLATFORM_C_FLAGS}"
+        CACHE STRING "" FORCE
+    )
+endif()
+
+if(DEFINED PLATFORM_CXX_FLAGS)
+    set(CMAKE_CXX_FLAGS
+        "${PLATFORM_CXX_FLAGS}"
+        CACHE STRING "" FORCE
+    )
+endif()
+
+if(DEFINED PLATFORM_EXE_LINKER_FLAGS)
+    set(CMAKE_EXE_LINKER_FLAGS
+        "${PLATFORM_EXE_LINKER_FLAGS}"
+        CACHE STRING "" FORCE
+    )
+endif()
+# ==============================================================================
+
 include("${CMAKE_SOURCE_DIR}/src/platforms.cmake")
 
 add_subdirectory(src)
@@ -34,3 +72,4 @@ if(TARGET_WINDOWS)
         message(FATAL_ERROR "...Aborting- project does not support Windows build")
     endif()
 endif()
+

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -7,7 +7,49 @@
   },
   "configurePresets": [
     {
+      "name": "common-avr32-paths",
+      "hidden": true,
+      "cacheVariables": {
+        "AVR32_INCLUDE_LIBRARIES": "C:/Program Files (x86)/Atmel/Studio/7.0/Packs/atmel/UC3L_DFP/1.0.59/include/AT32UC3L0256"
+      }
+    },
+    {
+      "name": "base-debug-flags",
+      "hidden": true,
+      "cacheVariables": {
+        "COMMON_C_FLAGS_DEBUG": "-O0 -g3 -Wall -DDEBUG",
+        "COMMON_ASM_FLAGS_DEBUG": "-O0 -g3 -DDEBUG" 
+      }
+    },
+    {
+      "name": "avr32-flags",
+      "hidden": true,
+      "inherits": ["base-debug-flags"],
+      "cacheVariables": {
+        "TARGET_AVR32": "ON",
+
+        "PLATFORM_C_FLAGS_DEBUG": "-ffunction-sections -fdata-sections -masm-addr-pseudos -std=gnu99 -mpart=uc3l0256 -DBOARD=USER_BOARD -fno-strict-aliasing",
+        "PLATFORM_ASM_FLAGS_DEBUG": "-ffunction-sections -masm-addr-pseudos -mpart=uc3l0256 -DBOARD=USER_BOARD",
+        "PLATFORM_EXE_LINKER_FLAGS":"-Wl,--gc-sections -Wl,--start-group -lm -Wl,--end-group --rodata-writable --direct-data -mpart=uc3l0256"
+      }
+    },
+    {
+      "name": "windows-flags",
+      "hidden": true,
+      "inherits": ["base-debug-flags"],
+      "cacheVariables": {
+        "TARGET_WINDOWS": "ON",
+
+        "PLATFORM_C_FLAGS":
+          "--coverage -ffile-prefix-map=${sourceDir}/=",
+
+        "PLATFORM_CXX_FLAGS":
+          "--coverage -ffile-prefix-map=${sourceDir}/="
+      }
+    },
+    {
       "name": "avr32-build",
+      "inherits": ["common-avr32-paths", "avr32-flags"],
       "displayName": "AVR32 MCU Debug Build",
       "description": "Debug build for AVR32 AT32UC3L0256 MCU",
       "generator": "Ninja",
@@ -20,15 +62,12 @@
         "AVR32_OBJDUMP": "C:/Program Files (x86)/Atmel/Studio/7.0/toolchain/avr32/avr32-gnu-toolchain/bin/avr32-objdump.exe",
         "AVR32_SIZE":    "C:/Program Files (x86)/Atmel/Studio/7.0/toolchain/avr32/avr32-gnu-toolchain/bin/avr32-size.exe",
         "CMAKE_C_COMPILER": "C:/Program Files (x86)/Atmel/Studio/7.0/toolchain/avr32/avr32-gnu-toolchain/bin/avr32-gcc.exe",
-        "AVR32_INCLUDE_LIBRARIES": "C:/Program Files (x86)/Atmel/Studio/7.0/Packs/atmel/UC3L_DFP/1.0.59/include/AT32UC3L0256",
-        "CMAKE_C_FLAGS_DEBUG": "-O0 -g3 -Wall -ffunction-sections -fdata-sections -masm-addr-pseudos -std=gnu99 -mpart=uc3l0256 -DDEBUG -DBOARD=USER_BOARD -fno-strict-aliasing",
-        "CMAKE_ASM_FLAGS_DEBUG": "-O0 -g3 -ffunction-sections -masm-addr-pseudos -mpart=uc3l0256 -DDEBUG -DBOARD=USER_BOARD",
-        "CMAKE_EXE_LINKER_FLAGS": "-Wl,--gc-sections -Wl,--start-group -lm -Wl,--end-group --rodata-writable -Wl,--direct-data -mpart=uc3l0256",
         "CMAKE_VERBOSE_MAKEFILE": "ON"
       }
     },
     {
       "name": "windows-build",
+      "inherits": ["common-avr32-paths", "windows-flags"],
       "displayName": "Windows Test Debug Build",
       "description": "Debug unit testing build for Windows",
       "generator": "Ninja",
@@ -37,9 +76,7 @@
         "TARGET_WINDOWS": "ON",
         "CMAKE_BUILD_TYPE": "Debug",
         "CMAKE_C_COMPILER": "C:/msys64/mingw64/bin/gcc.exe",
-        "CMAKE_CXX_COMPILER": "C:/msys64/mingw64/bin/g++.exe",
-        "CMAKE_C_FLAGS": "--coverage -ffile-prefix-map=${sourceDir}/=",
-        "CMAKE_CXX_FLAGS": "--coverage -ffile-prefix-map=${sourceDir}/="
+        "CMAKE_CXX_COMPILER": "C:/msys64/mingw64/bin/g++.exe"
       }
     }
   ],


### PR DESCRIPTION
- attempted to build ASF library on Windows by moving around build flags, but didn't work
- still good to factor out common build flags