### PR TITLE
feat: add a flag for windows build

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -40,11 +40,8 @@
       "cacheVariables": {
         "TARGET_WINDOWS": "ON",
 
-        "PLATFORM_C_FLAGS":
-          "--coverage -ffile-prefix-map=${sourceDir}/=",
-
-        "PLATFORM_CXX_FLAGS":
-          "--coverage -ffile-prefix-map=${sourceDir}/="
+        "PLATFORM_C_FLAGS": "--coverage -ffile-prefix-map=${sourceDir}/= -DWINDOWS_BUILD",
+        "PLATFORM_CXX_FLAGS": "--coverage -ffile-prefix-map=${sourceDir}/= -DWINDOWS_BUILD"
       }
     },
     {


### PR DESCRIPTION
the new `WINDOWS_BUILD` flag is used to get rid of compiler specific attributes in source code preventing tests from building