### PR TITLE
feat: disable cpputest memory leak detection for modern C++ libraries

### DIFF
--- a/cmake/tests/CMakeLists.txt
+++ b/cmake/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ project(windows_build LANGUAGES C CXX)
 include(FetchContent)
 
 set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
+set(CPPUTEST_MEM_LEAK_DETECTION_DISABLED ON CACHE BOOL "" FORCE)
 
 FetchContent_Declare(
     CppUTest


### PR DESCRIPTION
feat: disable cpputest memory leak detection to support modern C++ libraries